### PR TITLE
Include dependency definitions for Forge and Minecraft in mods.toml and specify side

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -10,10 +10,21 @@ updateJSONURL = "https://updates.blamejared.com/get?n=JEITweaker&gv=1.16.5"
 description = '''
 Adds JEI integration for CraftTweaker
 '''
-
-[[dependencies.jeitweaker]]
-modId = "jei"
-mandatory = true
-versionRange = "[7.7.1.110,)"
-ordering = "NONE"
-side = "BOTH"
+  [[dependencies.jeitweaker]]
+	modId = "forge"
+	mandatory = true
+	versionRange = "[32,)"
+	ordering = "NONE"
+	side = "BOTH"
+  [[dependencies.jeitweaker]]
+	modId = "minecraft"
+	mandatory = true
+	versionRange = "[1.16.1,)"
+	ordering = "NONE"
+	side = "BOTH"
+  [[dependencies.jeitweaker]]
+	modId = "jei"
+	mandatory = true
+	versionRange = "[7.7.1.110,)"
+	ordering = "NONE"
+	side = "BOTH"


### PR DESCRIPTION
I noticed that your mods.toml is missing the dependency definition for Forge and Minecraft.

mods.toml need to specify their sideness so Minecraft/Forge knows whether the mod needs to be available on the client, the server, or both. If a mod uses the modId for dependencies.<value_of_modId>, it also helps with ServerPackCreator identifying clientside-only mods. [Reference issue #70](https://github.com/Griefed/ServerPackCreator/issues/70) of ServerPackCreator.

Let me know what you think. 👋

Cheers,
Griefed